### PR TITLE
feat: Use unique addresses for Dallas temperature sensors

### DIFF
--- a/V6_3_DTC_page/FindAddresses.ino
+++ b/V6_3_DTC_page/FindAddresses.ino
@@ -1,0 +1,84 @@
+#include <OneWire.h>
+#include <DallasTemperature.h>
+
+// --- CONFIGURATION ---
+// Pin where the DS18B20 data line is connected
+const int ONE_WIRE_BUS_PIN = 25;
+
+// --- INITIALIZATION ---
+// Setup a oneWire instance to communicate with any OneWire devices
+OneWire oneWire(ONE_WIRE_BUS_PIN);
+
+// Pass our oneWire reference to Dallas Temperature sensor
+DallasTemperature sensors(&oneWire);
+
+// Variable to store device addresses
+DeviceAddress tempDeviceAddress;
+
+void setup(void) {
+  // Start serial communication for output
+  Serial.begin(115200);
+  Serial.println("Dallas Temperature Sensor Address Finder");
+
+  // Start up the Dallas Temperature library
+  sensors.begin();
+
+  // Locate devices on the bus and report how many were found.
+  int deviceCount = sensors.getDeviceCount();
+  Serial.print("Found ");
+  Serial.print(deviceCount, DEC);
+  Serial.println(" devices.");
+
+  if (deviceCount == 0) {
+    Serial.println("No devices found! Please check your wiring.");
+  } else {
+    Serial.println("Sensor addresses:");
+    // Loop through each device and print its address
+    for (int i = 0; i < deviceCount; i++) {
+      if (sensors.getAddress(tempDeviceAddress, i)) {
+        Serial.print("  Sensor ");
+        Serial.print(i + 1);
+        Serial.print(": ");
+        printAddress(tempDeviceAddress);
+        Serial.println();
+      }
+    }
+  }
+}
+
+void loop(void) {
+  // Request temperatures from all sensors on the bus
+  sensors.requestTemperatures();
+
+  int deviceCount = sensors.getDeviceCount();
+
+  // Loop through each device, print its address and temperature
+  for (int i = 0; i < deviceCount; i++) {
+    if (sensors.getAddress(tempDeviceAddress, i)) {
+      float tempC = sensors.getTempC(tempDeviceAddress);
+
+      Serial.print("Address: ");
+      printAddress(tempDeviceAddress);
+
+      // Check if the sensor could be read
+      if (tempC == DEVICE_DISCONNECTED_C) {
+        Serial.println(" | Could not read temperature");
+      } else {
+        Serial.print(" | Temp C: ");
+        Serial.println(tempC);
+      }
+    }
+  }
+
+  Serial.println("------------------------------------");
+  delay(5000); // Wait 5 seconds before the next scan
+}
+
+// Helper function to print a device address in a readable format
+void printAddress(DeviceAddress deviceAddress) {
+  for (uint8_t i = 0; i < 8; i++) {
+    // Add a "0" if the byte is less than 16
+    if (deviceAddress[i] < 16) Serial.print("0");
+    Serial.print(deviceAddress[i], HEX);
+  }
+}

--- a/V6_3_DTC_page/V6_3_DTC_page.ino
+++ b/V6_3_DTC_page/V6_3_DTC_page.ino
@@ -113,6 +113,19 @@ Bounce buttons[5];
 OneWire oneWire(TEMP_SENSOR_PIN);
 DallasTemperature sensors(&oneWire);
 
+// --- SENSOR ADDRESSES ---
+// Replace these placeholder addresses with the ones you found using FindAddresses.ino
+// DeviceAddress oilTempSensor = {0x28, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+// DeviceAddress iatSensor = {0x28, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+// DeviceAddress engineTempSensor = {0x28, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// To find your sensor addresses, upload and run the "FindAddresses.ino" sketch.
+// Then, copy the addresses here. For example:
+DeviceAddress oilTempSensor    = { 0x28, 0xFF, 0x64, 0x81, 0x86, 0x16, 0x03, 0x5F };
+DeviceAddress iatSensor        = { 0x28, 0xFF, 0x64, 0x81, 0x85, 0x16, 0x03, 0x9B };
+DeviceAddress engineTempSensor = { 0x28, 0xFF, 0x64, 0x81, 0x84, 0x16, 0x03, 0x9A };
+
+
 // —— ANALOG SENSORS ——
 #define OIL_PRESSURE_PIN 36
 #define MAP_PIN          39
@@ -660,7 +673,7 @@ inline float readBatteryVoltage() {
 }
 
 inline float readOilTemp() {
-  float t = sensors.getTempCByIndex(0);
+  float t = sensors.getTempC(oilTempSensor);
   if (t == DEVICE_DISCONNECTED_C) return NAN;
   t = t + oil_temp_offset;
   if (t < TEMP_MIN_OFFSET || t > TEMP_MAX_OFFSET) return NAN;
@@ -668,7 +681,7 @@ inline float readOilTemp() {
 }
 
 inline float readIAT() {
-  float t = sensors.getTempCByIndex(1);
+  float t = sensors.getTempC(iatSensor);
   if (t == DEVICE_DISCONNECTED_C) return NAN;
   t = t + iat_offset;
   if (t < TEMP_MIN_OFFSET || t > TEMP_MAX_OFFSET) return NAN;
@@ -676,7 +689,7 @@ inline float readIAT() {
 }
 
 inline float readEngineTemp() {
-  float t = sensors.getTempCByIndex(2);
+  float t = sensors.getTempC(engineTempSensor);
   if (t == DEVICE_DISCONNECTED_C) return NAN;
   t = t + engine_temp_offset;
   if (t < TEMP_MIN_OFFSET || t > TEMP_MAX_OFFSET) return NAN;


### PR DESCRIPTION
This commit improves the reliability of temperature readings by using unique hardware addresses to identify each Dallas temperature sensor, rather than relying on their index on the One-Wire bus, which can be unreliable.

- A new utility sketch, `FindAddresses.ino`, has been added. This sketch scans the One-Wire bus and prints the unique address of each connected sensor to the serial monitor, allowing the user to identify them physically.
- The main sketch, `V6_3_DTC_page.ino`, has been updated to use these unique addresses. The `readOilTemp()`, `readIAT()`, and `readEngineTemp()` functions now use `sensors.getTempC(deviceAddress)` instead of `sensors.getTempCByIndex()`.
- Placeholder addresses and clear instructions have been added to guide the user in updating the sketch with their specific sensor addresses.